### PR TITLE
Show confusable replacements in Char Info

### DIFF
--- a/Meziantou.OnlineTools/Pages/CharInfo.razor
+++ b/Meziantou.OnlineTools/Pages/CharInfo.razor
@@ -30,6 +30,23 @@
                             <td>@item.Block</td>
                         </tr>
                         <tr>
+                            <td class="column-info">Confusable:</td>
+                            <td>@(item.IsConfusable ? "Yes" : "No")</td>
+                        </tr>
+                        <tr>
+                            <td class="column-info">Replacement:</td>
+                            <td>
+                                @if (item.IsConfusable)
+                                {
+                                    <a href="@($"string-info?Text={Uri.EscapeDataString(item.ConfusableReplacement)}")">@item.ConfusableReplacement</a>
+                                }
+                                else
+                                {
+                                    <span>-</span>
+                                }
+                            </td>
+                        </tr>
+                        <tr>
                             <td class="column-info">Escape:</td>
                             <td>@item.Escape</td>
                         </tr>

--- a/Meziantou.OnlineTools/Utils/CharInfoWrapper.cs
+++ b/Meziantou.OnlineTools/Utils/CharInfoWrapper.cs
@@ -14,6 +14,8 @@ public sealed record CharInfoWrapper(UnicodeCharacterInfo CharInfo)
     public string Utf8Sequence => GetByteSequence(Encoding.UTF8.GetBytes(CharInfo.Rune.ToString()));
     public string Utf16Sequence => GetByteSequence(Encoding.Unicode.GetBytes(CharInfo.Rune.ToString()));
     public string Utf32Sequence => GetByteSequence(Encoding.UTF32.GetBytes(CharInfo.Rune.ToString()));
+    public bool IsConfusable => Unicode.IsConfusableCharacter(CharInfo.Rune);
+    public string ConfusableReplacement => Unicode.ReplaceConfusablesCharacters(CharInfo.Rune);
 
     private static string GetByteSequence(byte[] bytes)
         => string.Join(" ", bytes.Select(b => b.ToString("X2", CultureInfo.InvariantCulture)));


### PR DESCRIPTION
## Why
The Char Info page did not expose whether a character is confusable or what it maps to. This makes it harder to inspect suspicious look-alike characters.

## What changed
- Added confusable metadata to `CharInfoWrapper` using `Unicode.IsConfusableCharacter` and `Unicode.ReplaceConfusablesCharacters`.
- Updated `CharInfo.razor` to display `Confusable` and `Replacement` rows in the character details table.
- Rendered the replacement value as a link to `string-info?Text=...` (URL-encoded) so multi-character replacements can be inspected directly.

## Notes
- Link formatting is inlined in the Razor view to keep URL concerns in the UI layer.