### PR TITLE
Add file download for decoded Base64 output

### DIFF
--- a/Meziantou.OnlineTools/Pages/Base64Encode.razor
+++ b/Meziantou.OnlineTools/Pages/Base64Encode.razor
@@ -1,6 +1,7 @@
 @page "/base64-encode"
 @using System.Text
 @using System.IO
+@inject IJSRuntime JSRuntime
 
 <h1>Base64 Encode / Decode</h1>
 
@@ -28,11 +29,17 @@
     <ResultValueSingle CopyLabel="@(resultLabel ?? "result")" Value="@result" />
 }
 
+@if (decodedData != null)
+{
+    <button type="button" class="btn btn-primary" @onclick="DownloadDecodedDataAsync">Download decoded data</button>
+}
+
 @code {
     string? text;
     string? encoding;
     string? result;
     string? resultLabel;
+    byte[]? decodedData;
 
     private async Task OnInputFileChange(InputFileChangeEventArgs e)
     {
@@ -40,12 +47,14 @@
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);
 
+        decodedData = null;
         resultLabel = "Base64";
         result = Convert.ToBase64String(ms.ToArray());
     }
 
     void Encode()
     {
+        decodedData = null;
         resultLabel = "Base64";
         try
         {
@@ -59,14 +68,26 @@
 
     void Decode()
     {
+        decodedData = null;
         resultLabel = "Decoded text";
         try
         {
-            result = GetEncoding().GetString(Convert.FromBase64String(text ?? ""));
+            decodedData = Convert.FromBase64String(text ?? "");
+            result = GetEncoding().GetString(decodedData);
         }
         catch (Exception ex)
         {
             result = ex.Message;
+        }
+    }
+
+    async Task DownloadDecodedDataAsync()
+    {
+        if (decodedData != null)
+        {
+            using var stream = new MemoryStream(decodedData);
+            using var streamReference = new DotNetStreamReference(stream);
+            await JSRuntime.InvokeVoidAsync("downloadFileFromStream", "decoded-data.bin", streamReference);
         }
     }
 

--- a/Meziantou.OnlineTools/wwwroot/404.html
+++ b/Meziantou.OnlineTools/wwwroot/404.html
@@ -19,6 +19,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+    <script src="js/download.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/Meziantou.OnlineTools/wwwroot/index.html
+++ b/Meziantou.OnlineTools/wwwroot/index.html
@@ -19,6 +19,7 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+    <script src="js/download.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>
 

--- a/Meziantou.OnlineTools/wwwroot/js/download.js
+++ b/Meziantou.OnlineTools/wwwroot/js/download.js
@@ -1,0 +1,11 @@
+window.downloadFileFromStream = async (fileName, contentStreamReference) => {
+    const arrayBuffer = await contentStreamReference.arrayBuffer();
+    const blob = new Blob([arrayBuffer]);
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = fileName;
+    link.click();
+    link.remove();
+    URL.revokeObjectURL(url);
+};


### PR DESCRIPTION
## Summary
- Add a download action to the Base64 decode page when decoded bytes are available.
- Wire up a small JS helper to stream the decoded content to the browser as a file.
- Load the download helper from the app entry pages so it is available in both hosting paths.

## Testing
- Not run (not requested)