### PR TITLE
Sync String Info normalization with URL and input state

### DIFF
--- a/Meziantou.OnlineTools/Pages/StringInfo.razor
+++ b/Meziantou.OnlineTools/Pages/StringInfo.razor
@@ -4,7 +4,7 @@
 
 <h1>String Info</h1>
 
-<textarea class="form-control code" @oninput="OnChange">@Text</textarea>
+<textarea class="form-control code" @bind-value="Text" @bind-value:event="oninput" @bind-value:after="Compute"></textarea>
 
 <div>
     <button class="btn btn-secondary" @onclick="NormalizeC">Normalize Form C</button>
@@ -48,12 +48,6 @@
         Compute();
     }
 
-    void OnChange(ChangeEventArgs e)
-    {
-        Text = e.Value as string;
-        Compute();
-    }
-
     void Compute()
     {
         Text ??= "";
@@ -88,10 +82,12 @@
     void NormalizeC()
     {
         Text = Text?.Normalize(NormalizationForm.FormC);
+        Compute();
     }
 
     void NormalizeD()
     {
         Text = Text?.Normalize(NormalizationForm.FormD);
+        Compute();
     }
 }


### PR DESCRIPTION
This fixes a state synchronization issue on the String Info page where clicking normalization actions updated `Text` internally but did not refresh all UI/query state consistently.

## What changed
- Replaced the textarea `@oninput` handler with two-way binding to `Text` using `@bind-value` on `oninput`.
- Added `@bind-value:after="Compute"` so typing still recomputes results and query-string state.
- Updated `NormalizeC` and `NormalizeD` to call `Compute()` after normalization so the URL and computed values update immediately.

## Notes
The `OnChange` method is now unnecessary and was removed, since binding + `Compute` covers both input edits and normalization button actions.