### PR TITLE
Replace YamlDotNet with Meziantou.Framework.Yaml

### DIFF
--- a/Meziantou.OnlineTools/Meziantou.OnlineTools.csproj
+++ b/Meziantou.OnlineTools/Meziantou.OnlineTools.csproj
@@ -18,7 +18,7 @@
     <PackageReference Include="Meziantou.Framework.TextDiff" Version="3.0.0" />
     <PackageReference Include="Meziantou.GitLabClient" Version="1.1.26" />
     <PackageReference Include="Meziantou.Framework.QRCode" Version="2.0.0" />
-    <PackageReference Include="YamlDotNet" Version="18.0.0" />
+    <PackageReference Include="Meziantou.Framework.Yaml" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Meziantou.OnlineTools/Pages/YamlStringEncoder.razor
+++ b/Meziantou.OnlineTools/Pages/YamlStringEncoder.razor
@@ -24,8 +24,7 @@
         resultLabel = "YAML string";
         try
         {
-            var serializer = new YamlDotNet.Serialization.Serializer();
-            result = serializer.Serialize(text);
+            result = Meziantou.Framework.Yaml.YamlSerializer.Serialize(text);
         }
         catch (Exception ex)
         {
@@ -38,8 +37,7 @@
         resultLabel = "Decoded text";
         try
         {
-            var serializer = new YamlDotNet.Serialization.Deserializer();
-            result = serializer.Deserialize<object>(text ?? "")?.ToString();
+            result = Meziantou.Framework.Yaml.YamlSerializer.Deserialize<object>(text ?? "")?.ToString();
         }
         catch (Exception ex)
         {

--- a/Meziantou.OnlineTools/Pages/YamlToJson.razor
+++ b/Meziantou.OnlineTools/Pages/YamlToJson.razor
@@ -28,9 +28,7 @@
     {
         try
         {
-            var deserializer = new YamlDotNet.Serialization.Deserializer();
-            using var sr = new System.IO.StringReader(text ?? "");
-            var yamlObject = deserializer.Deserialize(sr);
+            var yamlObject = Meziantou.Framework.Yaml.YamlSerializer.Deserialize<object>(text ?? "");
 
             result = JsonUtils.ToDisplayJson(yamlObject);
         }


### PR DESCRIPTION
This replaces `YamlDotNet` with `Meziantou.Framework.Yaml` so the YAML tools use the in-house YAML stack consistently.

### What changed
- Replaced the package reference in `Meziantou.OnlineTools.csproj` with `Meziantou.Framework.Yaml`.
- Updated `YamlToJson.razor` to parse YAML using `Meziantou.Framework.Yaml.YamlSerializer.Deserialize<object>(...)`.
- Updated `YamlStringEncoder.razor` to use `YamlSerializer.Serialize(...)` and `YamlSerializer.Deserialize<object>(...)` directly.

### Notes
- No wrapper or compatibility types were introduced; the pages now call `Meziantou.Framework.Yaml` APIs directly.